### PR TITLE
Fix showkase

### DIFF
--- a/app/src/main/java/nl/jovmit/androiddevs/MainActivity.kt
+++ b/app/src/main/java/nl/jovmit/androiddevs/MainActivity.kt
@@ -9,20 +9,18 @@ import com.airbnb.android.showkase.models.Showkase
 import dagger.hilt.android.AndroidEntryPoint
 import nl.jovmit.androiddevs.core.view.theme.AppTheme
 
-@ShowkaseRoot
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-
         setContent {
             startActivity(Showkase.getBrowserIntent(this))
             finish()
-//            AppTheme {
-//                MainApp()
-//            }
+            AppTheme {
+                MainApp()
+            }
         }
     }
 }

--- a/core/view/build.gradle.kts
+++ b/core/view/build.gradle.kts
@@ -42,6 +42,12 @@ android {
     }
 }
 
+kapt {
+    arguments {
+        arg("skipPrivatePreviews", "true")
+    }
+}
+
 dependencies {
     api(platform(libs.compose.bom))
     api(libs.bundles.compose)

--- a/feature/postdetails/build.gradle.kts
+++ b/feature/postdetails/build.gradle.kts
@@ -52,6 +52,12 @@ android {
     }
 }
 
+kapt {
+    arguments {
+        arg("skipPrivatePreviews", "true")
+    }
+}
+
 dependencies {
     implementation(projects.core.view)
     implementation(libs.bundles.hilt)


### PR DESCRIPTION
Managed to make it work (see screenshot below)

Apparently, `androidx.activity.ComponentActivity` doesn't need to be annotated with `@ShowcaseRoot`

Additionally, I added `skipPrivateViews` in 2 more modules: `core:view` and `feature:postdetails`

```
kapt {
    arguments {
        arg("skipPrivatePreviews", "true")
    }
}
```

See the changes in this PR.